### PR TITLE
Stop detecting mobiles with colorbox

### DIFF
--- a/config/sync/colorbox.settings.yml
+++ b/config/sync/colorbox.settings.yml
@@ -24,7 +24,7 @@ custom:
     text_stop: 'stop slideshow'
 advanced:
   unique_token: 1
-  mobile_detect: 1
+  mobile_detect: 0
   mobile_device_width: 480px
   caption_trim: 0
   caption_trim_length: 75


### PR DESCRIPTION
We want to keep using colorbox because we want to display slides.