### PR TITLE
cleaning of config to support site:install

### DIFF
--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -17,18 +17,14 @@ jobs:
       # example: composer install
       - run: ddev composer install
 
-      # Install Psh CLI.
-      - name: Install Psh CLI
+      # Get ready to test with an empty-ish site.
+      - name: Prime a new empty site to test
         run: |
-          curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | bash
-
-      # Get the database to reflect main and run update.
-      - name: Fill database and bring Drupal up to date
-        run: |
-          platform db:dump --environment=main --project=nlw7xhb3fyt7y --stdout | ddev mysql
-          ddev exec drush -y cache-rebuild
-          ddev exec drush -y updatedb
-          ddev exec drush -y config-import
+          ddev exec drush -y site:install
+          ddev exec drush -y entity:delete shortcut
+          ddev exec drush -y config:set system.site uuid "457a53ee-ba47-433e-9fc2-314fff8a5c99"
+          ddev exec drush -y config:import
+          ddev exec drush -y cache:clear
 
       # Finally, run the tests.
       - name: Run Behat tests

--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -8,13 +8,15 @@ jobs:
   tests:
     runs-on: ubuntu-22.04
     steps:
+
+      # Actions from outside the project must be allowed in the project settings.
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Setup DDEV
         uses: ddev/github-action-setup-ddev@v1
 
-      # example: composer install
+      # Composer install
       - run: ddev composer install
 
       # Get ready to test with an empty-ish site.

--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -26,7 +26,7 @@ jobs:
           ddev exec drush -y entity:delete shortcut
           ddev exec drush -y config:set system.site uuid "457a53ee-ba47-433e-9fc2-314fff8a5c99"
           ddev exec drush -y config:import
-          ddev exec drush -y cache:clear
+          ddev exec drush -y cache:rebuild
 
       # Finally, run the tests.
       - name: Run Behat tests

--- a/config/sync/views.view.frontpage.yml
+++ b/config/sync/views.view.frontpage.yml
@@ -78,28 +78,6 @@ display:
           empty: true
           content: 'No front page content has been created yet.<br/>Follow the <a target="_blank" href="https://www.drupal.org/docs/user_guide/en/index.html">User Guide</a> to start building your site.'
           tokenize: false
-        node_listing_empty:
-          id: node_listing_empty
-          table: node
-          field: node_listing_empty
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          plugin_id: node_listing_empty
-          label: ''
-          empty: true
-        title:
-          id: title
-          table: views
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: title
-          label: ''
-          empty: true
-          title: 'Welcome to [site:name]'
       sorts:
         sticky:
           id: sticky

--- a/features/footer-contents.feature
+++ b/features/footer-contents.feature
@@ -7,9 +7,3 @@ Feature: Test Footer Contents
     Given I am on the homepage
     Then I should see Drupal in the "footer" region
 
-  Scenario: Test that Platform.sh is correctly linked in the footer
-    Given I am on the homepage
-    Then I should see the link "Platform.sh" in the "footer" region
-    When I click "Platform.sh" in the "footer" region
-    Then I should be on "https://platform.sh"
-


### PR DESCRIPTION
This should, at least, make it easier to run Behat in a CI environment without copying the db